### PR TITLE
Support Custom Hosts During Meeting Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ At present we cover the following modules
                     "duration" => 60, // in minutes
                     "timezone" => 'Asia/Dhaka', // set your timezone
                     "password" => 'set your password',
+                    "user" => 'user@example.com', // if a paid Zoom account has multiple users, you can pass a specific user ID to designate them as the host
                     "start_time" => 'set your start time', // set your start time
                     "template_id" => 'set your template id', // set your template id  Ex: "Dv4YdINdTk+Z5RToadh5ug==" from https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingtemplates
                     "pre_schedule" => false,  // set true if you want to create a pre-scheduled meeting

--- a/src/Zoom.php
+++ b/src/Zoom.php
@@ -60,8 +60,10 @@ class Zoom
     // create meeting
     public function createMeeting(array $data)
     {
+        $user = (isset($data['user'])) ? $data['user'] : 'me';
+        
         try {
-            $response = $this->client->request('POST', 'users/me/meetings', [
+            $response = $this->client->request('POST', 'users/' . $user . '/meetings', [
                 'json' => $data,
             ]);
             $res = json_decode($response->getBody(), true);


### PR DESCRIPTION
This PR updates the createMeeting function in Zoom.php to allow specifying a different user as the meeting host. Previously, the function defaulted to using the API caller’s account as the host. Now, if a paid Zoom account has multiple users, a specific user ID can be passed to designate them as the host. If no user is provided, it defaults to the current user.

Additionally, the documentation has been updated to include an example of passing a custom user ID when creating a meeting. This ensures users are aware of the new functionality and how to use it effectively.